### PR TITLE
Allow SQS client to be supplied in options

### DIFF
--- a/src/SqsWriteStream.js
+++ b/src/SqsWriteStream.js
@@ -36,7 +36,7 @@ class SqsWriteStream extends stream.Writable {
     Joi.assert(options, Joi.object());
 
     this.options = _.defaultsDeep(options, defaultOptions);
-    this.sqs = new SQS(this.options.config);
+    this.sqs = this.options.sqs || new SQS(this.options.config);
     this.buffer = [];
     this.queueName = queue.name;
     this.queueUrl = queue.url;


### PR DESCRIPTION
Hi, I've been trying to use your library with [aws-sdk-mock](https://github.com/dwyl/aws-sdk-mock) and was having trouble with the mocks not getting reset between tests.  I've made this change to supply an SQS client through the options object to facilitate testing.